### PR TITLE
Move return statement out of a finally block

### DIFF
--- a/dingtalk_stream/stream.py
+++ b/dingtalk_stream/stream.py
@@ -192,7 +192,8 @@ class DingTalkStreamClient(object):
             ip = s.getsockname()[0]
         finally:
             s.close()
-            return ip
+
+        return ip
 
     def reset_access_token(self):
         """ reset token if open api return 401 """


### PR DESCRIPTION
This causes a SyntaxWarning on Python 3.14: https://peps.python.org/pep-0765/